### PR TITLE
Handle translation of _ to - in documentation URLs

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -90,5 +90,13 @@ http {
         rewrite ^/ http://rocks.moonscript.org redirect;
       }
 
+      location /en/ {
+        rewrite_by_lua "
+           local uri = ngx.var.uri
+           local page = uri:gsub("^/en/", ""):gsub("_", "-")
+           ngx.redirect("http://github.com/keplerproject/luarocks/wiki/"..page)
+        ";
+      }
+
     }
 }


### PR DESCRIPTION
This should make the existing URLs for LuaRocks documentation that are out there (including in mailing list posts and caches of search engines) work again. I couldn't really test it here (apart from faking inputs in the terminal to check if my gsub's are correct), and I suppose you're using a more updated version of this file with some redirect from /en/ already in place, but I thought I'd save you work if I sent this your way. Thanks!

 (At some point I really need to learn how to setup a local MoonRocks installation so I can play around with it!)