### PR TITLE
Support www.luarocks.org (with "www")

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -77,7 +77,7 @@ http {
 
     server {
       listen ${{PORT}};
-      server_name luarocks.org;
+      server_name luarocks.org www.luarocks.org;
 
       location ~ ^/en\b(?<wikipath>.*) {
         rewrite_by_lua "


### PR DESCRIPTION
See keplerproject/luarocks#313

This seems to affect users running older versions of LuaRocks.
